### PR TITLE
cacheresource.pdo.php deprecation warning fix

### DIFF
--- a/demo/plugins/cacheresource.pdo.php
+++ b/demo/plugins/cacheresource.pdo.php
@@ -196,7 +196,7 @@ class Smarty_CacheResource_Pdo extends Smarty_CacheResource_Custom
      * @return void
      * @access protected
      */
-    protected function fetch($id, $name, $cache_id = null, $compile_id = null, &$content, &$mtime)
+    protected function fetch($id, $name, $cache_id = null, $compile_id = null, &$content = null, &$mtime = null)
     {
         $stmt = $this->getFetchStatement($this->fetchColumns, $id, $cache_id, $compile_id);
         $stmt->execute();
@@ -244,7 +244,7 @@ class Smarty_CacheResource_Pdo extends Smarty_CacheResource_Custom
      * @return boolean success
      * @access protected
      */
-    protected function save($id, $name, $cache_id = null, $compile_id = null, $exp_time, $content)
+    protected function save($id, $name, $cache_id = null, $compile_id = null, $exp_time = 0, $content = null)
     {
         $stmt = $this->pdo->prepare($this->insertStatement);
         $stmt->bindValue('id', $id);


### PR DESCRIPTION
I've been having deprecation warning due to wrong order of optional arguments in these two methods, which is causing my gitlab syntax check to fail.

The fix I've provided is as simple as it can get. Best solution, of course, would be to move those parameters around so that optional ones are at the end. But that requires making changes on all the places where these two methods are being called.